### PR TITLE
Allow spurious wake up for handling cancellation

### DIFF
--- a/src/events/windows.rs
+++ b/src/events/windows.rs
@@ -93,6 +93,11 @@ impl EventImpl for Event {
         }
     }
 
+    fn wait_allow_spurious_wake_up(&self, timeout: Timeout) -> Result<EventState> {
+        self.wait(timeout)?;
+        Ok(EventState::Signaled)
+    }
+
     fn set(&self, state: EventState) -> Result<()> {
         let res = match state {
             EventState::Clear => {


### PR DESCRIPTION
Context: I am using this library (and shared-memory) to build a simpler cross-process synchronization/communication protocol on top of it (I'm using it for hot reloading but it could be used for anything).

Here's the problem: On macOS, two threads cannot wait on the same cond variable. If this happens, the wait errors out with EINVAL (see https://wiki.sei.cmu.edu/confluence/display/c/POS53-C.+Do+not+use+more+than+one+mutex+for+concurrent+waiting+operations+on+a+condition+variable).

Now this is a problem for me because I need to be able to kill a first thread while it's waiting for an Event and spawn a new one. This is not some crazy kill, it's a standard SIGTERM. If I just let the OS do it, the mutex is reaquired and I get the error (I think https://linux.die.net/man/3/pthread_cond_wait has the relevant info on what happens on cancellations). This is a sucky behavior but I'm sure Cupertino experts had a good reason for it.

So to handle this, I need to use a custom signal hook and let the thread wake up. The problem is, this library is already handling the spurious wake ups, and ignores them. I need a way to hook into them.

I'm happy to rework this in any way if you can think of a better API.

The "client" of this library then does something like this:

```rust
    #[cfg(target_family = "unix")]
    {
      let is_being_killed = Arc::new(AtomicBool::new(false));
      let is_being_killed_for_handler = Arc::clone(&is_being_killed);
      let hook_id = unsafe {
        signal_hook::low_level::register(signal_hook::consts::signal::SIGTERM, move || {
          is_being_killed_for_handler.store(true, Ordering::Relaxed);
        })
        .unwrap()
      };
      while matches!(
        event.wait_allow_spurious_wake_up(Timeout::Infinite).unwrap(),
        EventState::Clear
      ) {
        if is_being_killed.load(Ordering::Relaxed) {
          signal_hook::low_level::unregister(hook_id);
          // This should probably be `unsafe { llibc::kill(std::process::id() as i32, libc::SIGTERM); }` 
          // but it doesn't suspend the thread for me 🤷.
          std::process::abort();
        }
      }
    }
    #[cfg(not(target_family = "unix"))]
    {
      self.memory.event.wait(Timeout::Infinite).unwrap();
    }