### PR TITLE
Upgrade nix to 0.24, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ rand = "0.8"
 winapi = { version = "0.3", features = ["winnt", "winbase", "winerror", "ntdef", "synchapi", "handleapi"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = [] }
 libc = "0.2"


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and decreases build times.